### PR TITLE
Fix Mercury token file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ npm run build
 npm run lint
 
 # copy config.example.js in renderer to config.js by executing cp config.example.js config.js and set Mercury parser token
-cp src/renderer/config.example.js config.js
+cp src/renderer/config.example.js src/renderer/config.js
 
 ```
 


### PR DESCRIPTION
`./src/renderer/parsers/article.js` import **Mercury Web Parser API Key** from the config file in `./src/renderer/config` not `./config.js`.
Following the current `Build Setup` will output, the following:
<pre>
<code style="color: red;">
ERROR in ./src/renderer/parsers/article.js
  Module not found: Error: Can't resolve '../config' in '/home/user/Documents/raven-reader/src/renderer/parsers'
   @ ./src/renderer/parsers/article.js 5:0-46 24:29-46
   @ ./node_modules/babel-loader/lib!./node_modules/vue-loader/lib??vue-loader-options!./src/renderer/views/Main.vue?vue&amp;type=script&amp;lang=js&amp;
   @ ./src/renderer/views/Main.vue?vue&amp;type=script&amp;lang=js&amp;
   @ ./src/renderer/views/Main.vue
   @ ./src/renderer/router/index.js
   @ ./src/renderer/main.js
   @ multi ./.electron-vue/dev-client ./src/renderer/main.js

  ERROR in ./src/renderer/services/cacheArticle.js
  Module not found: Error: Can't resolve '../config' in '/home/user/Documents/raven-reader/src/renderer/services'
   @ ./src/renderer/services/cacheArticle.js 5:0-46 22:31-48 122:31-48
   @ ./node_modules/babel-loader/lib!./node_modules/vue-loader/lib??vue-loader-options!./src/renderer/components/ArticleToolbar.vue?vue&amp;type=script&amp;lang=js&amp;
   @ ./src/renderer/components/ArticleToolbar.vue?vue&amp;type=script&amp;lang=js&amp;
   @ ./src/renderer/components/ArticleToolbar.vue
   @ ./src/renderer/components/register.js
   @ ./src/renderer/main.js
   @ multi ./.electron-vue/dev-client ./src/renderer/main.js
</code>
</pre>